### PR TITLE
Use extension per algorithm

### DIFF
--- a/SmartArchiver/Form1.cs
+++ b/SmartArchiver/Form1.cs
@@ -61,7 +61,15 @@ namespace SmartArchiver
                     var tokenSource = new System.Threading.CancellationTokenSource();
                     try
                     {
-                        double ratio = HuffmanArchive.CompressFiles(files, archiveName + ".huff", tokenSource.Token);
+                        double ratio;
+                        if (optionsForm.SelectedMethod == "Huffman")
+                        {
+                            ratio = HuffmanArchive.CompressFiles(files, archiveName + ".huff", tokenSource.Token);
+                        }
+                        else
+                        {
+                            ratio = ShannonFanoArchive.CompressFiles(files, archiveName + ".shfn", tokenSource.Token);
+                        }
                         MessageBox.Show($"Compression complete. Ratio: {ratio:F2}%", "Done", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }
                     catch (OperationCanceledException)
@@ -89,7 +97,7 @@ namespace SmartArchiver
         {
             using (OpenFileDialog ofd = new OpenFileDialog())
             {
-                ofd.Filter = "Huffman Archive|*.huff";
+                ofd.Filter = "Archive Files|*.huff;*.shfn";
                 if (ofd.ShowDialog() == DialogResult.OK)
                 {
                     using (FolderBrowserDialog fbd = new FolderBrowserDialog())
@@ -99,7 +107,15 @@ namespace SmartArchiver
                             var tokenSource = new System.Threading.CancellationTokenSource();
                             try
                             {
-                                HuffmanArchive.ExtractAll(ofd.FileName, fbd.SelectedPath, tokenSource.Token);
+                                string ext = Path.GetExtension(ofd.FileName).ToLowerInvariant();
+                                if (ext == ".huff")
+                                {
+                                    HuffmanArchive.ExtractAll(ofd.FileName, fbd.SelectedPath, tokenSource.Token);
+                                }
+                                else
+                                {
+                                    ShannonFanoArchive.ExtractAll(ofd.FileName, fbd.SelectedPath, tokenSource.Token);
+                                }
                                 MessageBox.Show("Extraction complete.", "Done", MessageBoxButtons.OK, MessageBoxIcon.Information);
                             }
                             catch (OperationCanceledException)

--- a/SmartArchiver/Form2.cs
+++ b/SmartArchiver/Form2.cs
@@ -15,11 +15,13 @@ namespace SmartArchiver
     {
         public string ArchiveName => archiveNameBox.Text.Trim();
         public string Password => passwordBox.Text;
+        public string SelectedMethod => comboBox1.SelectedItem as string;
 
         public Form2()
         {
             InitializeComponent();
             warningLabel.Visible = false;
+            comboBox1.SelectedIndex = 0;
         }
 
         private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add `SelectedMethod` property on options form
- default to first compression method
- choose archive extension depending on selected compression algorithm
- extract archives with either `.huff` or `.shfn`

## Testing
- `dotnet build SmartArchiver.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea15a7abc83219ed7d30952d4b98b